### PR TITLE
Fog of vision implementation

### DIFF
--- a/src/components.rs
+++ b/src/components.rs
@@ -197,11 +197,21 @@ pub enum Direction {
 }
 
 /// What we can see from a certain point.
+#[derive(new)]
 pub struct Viewshed {
     /// Which tiles we can see.
     pub visible_tiles: Vec<Point>,
     /// How many tiles ahead we can see.
     pub range: i32,
+}
+
+impl Default for Viewshed {
+    fn default() -> Self {
+        Self {
+            visible_tiles: Vec::new(),
+            range: 0,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/components.rs
+++ b/src/components.rs
@@ -113,6 +113,12 @@ impl CollisionMap {
     }
 }
 
+impl Algorithm2D for CollisionMap {
+    fn dimensions(&self) -> Point {
+        Point::new(self.width, self.height)
+    }
+}
+
 impl BaseMap for CollisionMap {
     fn is_opaque(&self, idx: usize) -> bool {
         self.bitset.contains(idx as u32)

--- a/src/components.rs
+++ b/src/components.rs
@@ -196,6 +196,14 @@ pub enum Direction {
     Down,
 }
 
+/// What we can see from a certain point.
+pub struct Viewshed {
+    /// Which tiles we can see.
+    pub visible_tiles: Vec<Point>,
+    /// How many tiles ahead we can see.
+    pub range: i32,
+}
+
 #[cfg(test)]
 mod tests {
     use crate::*;

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,5 +1,7 @@
 use crate::*;
 
+use std::collections::HashSet;
+
 /// A single colored letter sprite.
 pub struct Sprite {
     /// The char symbol displayed.
@@ -196,20 +198,17 @@ pub enum Direction {
     Down,
 }
 
-/// What we can see from a certain point.
+/// Everything we can see from.
 #[derive(new)]
 pub struct Viewshed {
     /// Which tiles we can see.
-    pub visible_tiles: Vec<Point>,
-    /// How many tiles ahead we can see.
-    pub range: i32,
+    pub visible_tiles: HashSet<Point>,
 }
 
 impl Default for Viewshed {
     fn default() -> Self {
         Self {
-            visible_tiles: Vec::new(),
-            range: 0,
+            visible_tiles: HashSet::new(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,10 @@ pub extern crate hibitset;
 extern crate crossterm;
 
 pub use bracket_lib::prelude::{
-    a_star_search, add_wasm_support, main_loop, to_cp437, field_of_view, BError, BEvent, BTerm, BTermBuilder,
-    BaseMap, GameState, MultiTileSprite, NavigationPath, Point, Rect, SmallVec, SpriteSheet,
-    VirtualKeyCode, BLACK, BLUE, EMBED, GREEN, INPUT, RED, RGBA, WHITE, YELLOW, Algorithm2D,
+    a_star_search, add_wasm_support, field_of_view, main_loop, to_cp437, Algorithm2D, BError,
+    BEvent, BTerm, BTermBuilder, BaseMap, GameState, MultiTileSprite, NavigationPath, Point, Rect,
+    SmallVec, SpriteSheet, VirtualKeyCode, BLACK, BLUE, EMBED, GREEN, INPUT, RED, RGBA, WHITE,
+    YELLOW,
 };
 pub use game_clock::*;
 pub use game_features::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ extern crate crossterm;
 pub use bracket_lib::prelude::{
     a_star_search, add_wasm_support, field_of_view, main_loop, to_cp437, Algorithm2D, BError,
     BEvent, BTerm, BTermBuilder, BaseMap, GameState, MultiTileSprite, NavigationPath, Point, Rect,
-    SmallVec, SpriteSheet, VirtualKeyCode, BLACK, BLUE, EMBED, GREEN, INPUT, RED, RGBA, WHITE,
+    SmallVec, SpriteSheet, VirtualKeyCode, BLACK, BLUE, EMBED, GREEN, INPUT, RED, DIMGRAY, RGBA, WHITE,
     YELLOW,
 };
 pub use game_clock::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ extern crate crossterm;
 pub use bracket_lib::prelude::{
     a_star_search, add_wasm_support, field_of_view, main_loop, to_cp437, Algorithm2D, BError,
     BEvent, BTerm, BTermBuilder, BaseMap, GameState, MultiTileSprite, NavigationPath, Point, Rect,
-    SmallVec, SpriteSheet, VirtualKeyCode, BLACK, BLUE, EMBED, GREEN, INPUT, RED, DIMGRAY, RGBA, WHITE,
+    SmallVec, SpriteSheet, VirtualKeyCode, BLACK, BLUE, EMBED, GREEN, INPUT, RED, RGBA, WHITE,
     YELLOW,
 };
 pub use game_clock::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,9 @@ pub extern crate hibitset;
 extern crate crossterm;
 
 pub use bracket_lib::prelude::{
-    a_star_search, add_wasm_support, main_loop, to_cp437, BError, BEvent, BTerm, BTermBuilder,
+    a_star_search, add_wasm_support, main_loop, to_cp437, field_of_view, BError, BEvent, BTerm, BTermBuilder,
     BaseMap, GameState, MultiTileSprite, NavigationPath, Point, Rect, SmallVec, SpriteSheet,
-    VirtualKeyCode, BLACK, BLUE, EMBED, GREEN, INPUT, RED, RGBA, WHITE, YELLOW,
+    VirtualKeyCode, BLACK, BLUE, EMBED, GREEN, INPUT, RED, RGBA, WHITE, YELLOW, Algorithm2D,
 };
 pub use game_clock::*;
 pub use game_features::*;

--- a/src/render.rs
+++ b/src/render.rs
@@ -68,7 +68,7 @@ pub fn render_sprites<'a>(
                     1,
                 ),
                 0,
-                RGBA::named(DIMGRAY),
+                RGBA::from_u8(160, 160, 160, 255),
                 sprite.0,
             );
         }

--- a/src/render.rs
+++ b/src/render.rs
@@ -38,21 +38,27 @@ pub fn render_sprites<'a>(
     camera: &Camera,
     positions: &Components<Point>,
     sprites: &Components<SpriteIndex>,
+    viewsheds: &Components<Viewshed>,
 ) {
-    for (pos, sprite) in join!(&positions && &sprites) {
-        let pos = pos.unwrap();
-        let sprite = sprite.unwrap();
-        ctx.add_sprite(
-            Rect::with_size(
-                (pos.x - camera.position.x) * 1,
-                (pos.y - camera.position.y) * 1,
-                // TODO make this dynamic.
-                1,
-                1,
-            ),
-            0,
-            RGBA::named(WHITE),
-            sprite.0,
-        );
+    for viewshed in viewsheds.iter() {
+        for (pos, sprite) in join!(&positions && &sprites) {
+            let pos = pos.unwrap();
+            let sprite = sprite.unwrap();
+            if viewshed.visible_tiles.contains(&pos) {
+                ctx.add_sprite(
+                    Rect::with_size(
+                        (pos.x - camera.position.x) * 1,
+                        (pos.y - camera.position.y) * 1,
+                        // TODO make this dynamic.
+                        1,
+                        1,
+                    ),
+                    0,
+                    RGBA::named(WHITE),
+                    sprite.0,
+                );
+            }
+        }
+
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -38,27 +38,24 @@ pub fn render_sprites<'a>(
     camera: &Camera,
     positions: &Components<Point>,
     sprites: &Components<SpriteIndex>,
-    viewsheds: &Components<Viewshed>,
+    viewshed: &Viewshed,
 ) {
-    for viewshed in viewsheds.iter() {
-        for (pos, sprite) in join!(&positions && &sprites) {
-            let pos = pos.unwrap();
-            let sprite = sprite.unwrap();
-            if viewshed.visible_tiles.contains(&pos) {
-                ctx.add_sprite(
-                    Rect::with_size(
-                        (pos.x - camera.position.x) * 1,
-                        (pos.y - camera.position.y) * 1,
-                        // TODO make this dynamic.
-                        1,
-                        1,
-                    ),
-                    0,
-                    RGBA::named(WHITE),
-                    sprite.0,
-                );
-            }
+    for (pos, sprite) in join!(&positions && &sprites) {
+        let pos = pos.unwrap();
+        let sprite = sprite.unwrap();
+        if viewshed.visible_tiles.contains(&pos) {
+            ctx.add_sprite(
+                Rect::with_size(
+                    (pos.x - camera.position.x) * 1,
+                    (pos.y - camera.position.y) * 1,
+                    // TODO make this dynamic.
+                    1,
+                    1,
+                ),
+                0,
+                RGBA::named(WHITE),
+                sprite.0,
+            );
         }
-
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -38,13 +38,13 @@ pub fn render_sprites<'a>(
     camera: &Camera,
     positions: &Components<Point>,
     sprites: &Components<SpriteIndex>,
-    viewshed: &Viewshed,
+    viewshed: Option<&Viewshed>,
 ) {
     for (pos, sprite) in join!(&positions && &sprites) {
         let pos = pos.unwrap();
         let sprite = sprite.unwrap();
 
-        if viewshed.visible_tiles.contains(&pos) {
+        if viewshed.is_none() || viewshed.unwrap().visible_tiles.contains(&pos) {
             ctx.add_sprite(
                 Rect::with_size(
                     (pos.x - camera.position.x) * 1,
@@ -57,6 +57,7 @@ pub fn render_sprites<'a>(
                 RGBA::named(WHITE),
                 sprite.0,
             );
+
         // TODO this will not hide units that are not creeps, use a better way of checking for enemy units.
         } else if sprite.0 != 9 {
             ctx.add_sprite(

--- a/src/render.rs
+++ b/src/render.rs
@@ -43,6 +43,7 @@ pub fn render_sprites<'a>(
     for (pos, sprite) in join!(&positions && &sprites) {
         let pos = pos.unwrap();
         let sprite = sprite.unwrap();
+
         if viewshed.visible_tiles.contains(&pos) {
             ctx.add_sprite(
                 Rect::with_size(
@@ -54,6 +55,20 @@ pub fn render_sprites<'a>(
                 ),
                 0,
                 RGBA::named(WHITE),
+                sprite.0,
+            );
+        // TODO this will not hide units that are not creeps, use a better way of checking for enemy units.
+        } else if sprite.0 != 9 {
+            ctx.add_sprite(
+                Rect::with_size(
+                    (pos.x - camera.position.x) * 1,
+                    (pos.y - camera.position.y) * 1,
+                    // TODO make this dynamic.
+                    1,
+                    1,
+                ),
+                0,
+                RGBA::named(DIMGRAY),
                 sprite.0,
             );
         }


### PR DESCRIPTION
This PR aims to bring a minimal capability of the *fog of vision*. It implements a `Viewshed` resource to hold all visible tiles and in `render_sprites` only renders the ones visible.